### PR TITLE
use homepath in place of C:\

### DIFF
--- a/src/compresswindow.cpp
+++ b/src/compresswindow.cpp
@@ -67,7 +67,7 @@ void CompressWindow::on_addFilesButton_clicked()
     QStringList files = QFileDialog::getOpenFileNames(
                 this,
                 "Files to Compress",
-                "C://",
+                QDir::homePath(),
                 "All Files (*.*)");
     QStringList list = files;
     QStringList::Iterator it = list.begin();

--- a/src/extractwindow.cpp
+++ b/src/extractwindow.cpp
@@ -62,7 +62,7 @@ void ExtractWindow::on_inputButton_clicked()
     QString filename=QFileDialog::getOpenFileName (
                 this,
                 tr("Open File to Extract..."),
-                "C://",
+                QDir::homePath(),
                 "Frog File (*.frog)"
                 );
     if (filename.isEmpty()) //Cancel Open File
@@ -75,7 +75,7 @@ void ExtractWindow::on_outputDirButton_clicked()
 {
     QString outputdir = QFileDialog::getExistingDirectory(this,
                                                           tr("Choose Directory to Extract"),
-                                                          "C:\\");
+                                                          QDir::homePath());
     if (outputdir.isEmpty())
         ui->textEdit->setText("Operation Canceled");
     else


### PR DESCRIPTION
Use the QDir::homePath() inplace of C:\ as a default location for better portablity between OSes