### PR TITLE
remove opperation cancelled text

### DIFF
--- a/src/compresswindow.cpp
+++ b/src/compresswindow.cpp
@@ -69,17 +69,15 @@ void CompressWindow::on_addFilesButton_clicked()
                 "Files to Compress",
                 QDir::homePath(),
                 "All Files (*.*)");
+
+    if(files.isEmpty())
+        return;
+
     QStringList::Iterator it = files.begin();
     //Proccessing List
-    if (it==files.end()) //Cancel or no files
-    {
-        ui->textEdit->setText("Operation Canceled.");
-    } else
-    {
-        while(it != files.end()) {
-            ui->listWidget->addItem(*it);
-            ++it;
-        }
+    while(it != files.end()) {
+        ui->listWidget->addItem(*it);
+        ++it;
     }
 }
 

--- a/src/extractwindow.cpp
+++ b/src/extractwindow.cpp
@@ -44,11 +44,7 @@ void ExtractWindow::Extract() {
     ui->progressBar->setValue(0);
     QString filename = ui->inputFile->text();
     QString output = ui->extractPosition->text();
-    if (filename.isEmpty() && output.isEmpty()) //Cancel Open File
-    {
-        ui->textEdit->setText("Operation Canceled");
-    } else //Open File
-    {
+    if (!filename.isEmpty() && !output.isEmpty()) {
         ui->textEdit->setText("");
         huffmanDecoding->setInputFile(filename);
         huffmanDecoding->setOutputFile(output);
@@ -65,9 +61,7 @@ void ExtractWindow::on_inputButton_clicked()
                 QDir::homePath(),
                 "Frog File (*.frog)"
                 );
-    if (filename.isEmpty()) //Cancel Open File
-        ui->textEdit->setText("Operation Canceled");
-    else //Open File
+    if (!filename.isEmpty())
         ui->inputFile->setText(filename);
 }
 
@@ -76,9 +70,7 @@ void ExtractWindow::on_outputDirButton_clicked()
     QString outputdir = QFileDialog::getExistingDirectory(this,
                                                           tr("Choose Directory to Extract"),
                                                           QDir::homePath());
-    if (outputdir.isEmpty())
-        ui->textEdit->setText("Operation Canceled");
-    else
+    if (!outputdir.isEmpty())
         ui->extractPosition->setText(outputdir);
 }
 


### PR DESCRIPTION
Remove the "Operation Cancelled" Text.  Abort the operations if no file has been selected. The text is misleading and shows often by default.