### PR TITLE
Remove Use of auto gen slot names on_foo_something

### DIFF
--- a/src/about.cpp
+++ b/src/about.cpp
@@ -7,8 +7,7 @@ About::About(QWidget *parent) : QDialog(parent), ui(new Ui::About) {
   ui->pushButton->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
   ui->pushButton->setIconSize(
       QSize(fontMetrics().height(), fontMetrics().height()));
+  connect(ui->pushButton, &QPushButton::clicked, this, &QDialog::close);
 }
 
 About::~About() { delete ui; }
-
-void About::on_pushButton_clicked() { this->close(); }

--- a/src/about.h
+++ b/src/about.h
@@ -16,9 +16,6 @@ public:
   explicit About(QWidget *parent = 0);
   ~About();
 
-private slots:
-  void on_pushButton_clicked();
-
 private:
   Ui::About *ui;
 };

--- a/src/compresswindow.cpp
+++ b/src/compresswindow.cpp
@@ -9,13 +9,21 @@ CompressWindow::CompressWindow(QWidget *parent)
   setModal(true);
 
   QSize iconSize = QSize(fontMetrics().height(), fontMetrics().height());
+
+  connect(ui->saveAsButton, &QPushButton::clicked, this, &CompressWindow::saveAs);
+
   ui->addFilesButton->setIcon(style()->standardIcon(QStyle::SP_FileIcon));
   ui->addFilesButton->setIconSize(iconSize);
+  connect(ui->addFilesButton, &QPushButton::clicked, this, &CompressWindow::addFiles);
+
   ui->clearListButton->setIcon(
       style()->standardIcon(QStyle::SP_DialogDiscardButton));
   ui->clearListButton->setIconSize(iconSize);
+  connect(ui->clearListButton, &QPushButton::clicked, ui->listWidget, &QListWidget::clear);
+
   ui->embedButton->setIcon(style()->standardIcon(QStyle::SP_DialogSaveButton));
   ui->embedButton->setIconSize(iconSize);
+  connect(ui->embedButton, &QPushButton::clicked, this, &CompressWindow::compress);
 
   huffmanEncoding = new HuffmanEncoding();
   connect(huffmanEncoding, &HuffmanEncoding::started, this,
@@ -54,7 +62,7 @@ void CompressWindow::disabledButton() {
   ui->saveLocation->setDisabled(true);
 }
 
-void CompressWindow::on_addFilesButton_clicked() {
+void CompressWindow::addFiles() {
   ui->progressBar->setValue(0);
   // Select Files
   QStringList files = QFileDialog::getOpenFileNames(
@@ -71,7 +79,7 @@ void CompressWindow::on_addFilesButton_clicked() {
   }
 }
 
-void CompressWindow::on_saveAsButton_clicked() {
+void CompressWindow::saveAs() {
   QString outputfile = QFileDialog::getSaveFileName(
       this, tr("Save As"), QString(), tr("Frog File (*.frog)"));
   if (outputfile.isNull() || outputfile.isEmpty()) // Cancel
@@ -86,9 +94,7 @@ void CompressWindow::on_saveAsButton_clicked() {
   }
 }
 
-void CompressWindow::on_clearListButton_clicked() { ui->listWidget->clear(); }
-
-void CompressWindow::on_embedButton_clicked() {
+void CompressWindow::compress() {
   if (ui->listWidget->count() > 0 && ui->saveLocation->text().length() > 0) {
     // Disabled Button
     disabledButton();

--- a/src/compresswindow.h
+++ b/src/compresswindow.h
@@ -16,13 +16,9 @@ public:
   ~CompressWindow();
 
 private slots:
-  void on_addFilesButton_clicked();
-
-  void on_saveAsButton_clicked();
-
-  void on_clearListButton_clicked();
-
-  void on_embedButton_clicked();
+  void addFiles();
+  void saveAs();
+  void compress();
 
 protected:
   void showEvent(QShowEvent *) override;

--- a/src/extractwindow.cpp
+++ b/src/extractwindow.cpp
@@ -7,6 +7,11 @@ ExtractWindow::ExtractWindow(QWidget *parent)
     : QDialog(parent), ui(new Ui::ExtractWindow) {
   ui->setupUi(this);
   setModal(true);
+
+  connect(ui->extractButton, &QPushButton::clicked, this, &ExtractWindow::Extract);
+  connect(ui->inputButton, &QPushButton::clicked, this, &ExtractWindow::pickInputFile);
+  connect(ui->outputDirButton, &QPushButton::clicked, this, &ExtractWindow::pickOutputPath);
+
   huffmanDecoding = new HuffmanDecoding();
   connect(huffmanDecoding, &HuffmanDecoding::started, this,
           [this] { ui->progressBar->setHidden(false); });
@@ -48,7 +53,7 @@ void ExtractWindow::Extract() {
   }
 }
 
-void ExtractWindow::on_inputButton_clicked() {
+void ExtractWindow::pickInputFile() {
   QString filename =
       QFileDialog::getOpenFileName(this, tr("Open File to Extract..."),
                                    QDir::homePath(), "Frog File (*.frog)");
@@ -56,11 +61,9 @@ void ExtractWindow::on_inputButton_clicked() {
     ui->inputFile->setText(filename);
 }
 
-void ExtractWindow::on_outputDirButton_clicked() {
+void ExtractWindow::pickOutputPath() {
   QString outputdir = QFileDialog::getExistingDirectory(
       this, tr("Choose Directory to Extract"), QDir::homePath());
   if (!outputdir.isEmpty())
     ui->extractPosition->setText(outputdir);
 }
-
-void ExtractWindow::on_extractButton_clicked() { Extract(); }

--- a/src/extractwindow.h
+++ b/src/extractwindow.h
@@ -17,11 +17,8 @@ public:
   void Extract();
 
 private slots:
-  void on_inputButton_clicked();
-
-  void on_outputDirButton_clicked();
-
-  void on_extractButton_clicked();
+  void pickInputFile();
+  void pickOutputPath();
 
 protected:
   void showEvent(QShowEvent *) override;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,6 +20,10 @@ MainWindow::MainWindow(QWidget *parent)
   ui->mainToolBar->addAction(ui->actionExtract);
   connect(ui->actionExtract, &QAction::triggered, this, &MainWindow::Extract);
   connect(ui->buttonExtract, &QPushButton::pressed, this, &MainWindow::Extract);
+
+  connect(ui->actionExit, &QAction::triggered, this, &QApplication::quit);
+  connect(ui->actionAbout, &QAction::triggered, this, &MainWindow::showAbout);
+  connect(ui->actionLicense, &QAction::triggered, this, &MainWindow::showLicense);
 }
 
 MainWindow::~MainWindow() {
@@ -28,9 +32,7 @@ MainWindow::~MainWindow() {
   delete ui;
 }
 
-void MainWindow::on_actionExit_triggered() { QApplication::quit(); }
-
-void MainWindow::on_actionAbout_triggered() {
+void MainWindow::showAbout() {
   About Ab1;
   Ab1.setModal(true);
   Ab1.exec();
@@ -40,7 +42,7 @@ void MainWindow::Extract() { extractWindow->show(); }
 
 void MainWindow::Compress() { compressWindow->show(); }
 
-void MainWindow::on_actionLicense_triggered() {
+void MainWindow::showLicense() {
   License license;
   license.setModal(true);
   license.exec();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -33,11 +33,8 @@ public:
   ~MainWindow();
 
 private slots:
-  void on_actionExit_triggered();
-
-  void on_actionAbout_triggered();
-
-  void on_actionLicense_triggered();
+  void showAbout();
+  void showLicense();
 
 private:
   Ui::MainWindow *ui;


### PR DESCRIPTION
the auto generated on_foo_action slots are dangerous. I've replaced them with normal slot names and connected them. Some that were simple method calls are now just a connection instead.